### PR TITLE
style: match v1 casing between signature and CLA

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_sign_cla.yml
+++ b/.github/ISSUE_TEMPLATE/01_sign_cla.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        # Thousand Brains Project - Contributor License Agreement ("CLA") V1
+        # Thousand Brains Project - Contributor License Agreement ("CLA") v1
 
         Thank you for your interest in contributing to the Thousand Brains Project ("TBP"). The TBP is very interested in receiving Your Contribution (defined below). In order to participate, we need to confirm how the rights in Your Contribution will be handled. Following the practices of other open source communities, TBP requests that you grant TBP a license, as indicated below, to the intellectual property rights in Your Contributions. TBP requires that you have a Contributor License Agreement ("CLA") on file prior to using any of Your Contributions. This helps us ensure that the intellectual property embodied within TBP remains unencumbered for use by the whole of the community. This CLA includes other terms as well and is for your protection as a Contributor as well as the protection of TBP and its users; it does not change your rights to use Your Contributions for any other purpose.
 

--- a/cla_v1.md
+++ b/cla_v1.md
@@ -1,4 +1,4 @@
-# Thousand Brains Project - Contributor License Agreement ("CLA") V1
+# Thousand Brains Project - Contributor License Agreement ("CLA") v1
 
 Thank you for your interest in contributing to the Thousand Brains Project ("TBP"). The TBP is very interested in receiving Your Contribution (defined below). In order to participate, we need to confirm how the rights in Your Contribution will be handled. Following the practices of other open source communities, TBP requests that you grant TBP a license, as indicated below, to the intellectual property rights in Your Contributions. TBP requires that you have a Contributor License Agreement ("CLA") on file prior to using any of Your Contributions. This helps us ensure that the intellectual property embodied within TBP remains unencumbered for use by the whole of the community. This CLA includes other terms as well and is for your protection as a Contributor as well as the protection of TBP and its users; it does not change your rights to use Your Contributions for any other purpose.
 


### PR DESCRIPTION
Ensuring that the title casing matches between signature and CLA itself.