### PR TITLE
docs: more context in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Thousand Brains Project Contributor License Agreement (CLA)
 
-This repository is used to manage the Thousand Brains Project Contributor License Agreement (CLA).
-
 ## Overview
 
-The CLA is a document that you must sign before you can contribute to the Thousand Brains Project. It is a legal document that grants the Thousand Brains Project a license to use your contributions.
+Thank you for your interest in contributing to the Thousand Brains Project. We appreciate and look forward to your contributions. In order to participate, we need to confirm how the rights in your contribution will be handled.
+
+Following the practices of other open source communities, the Thousand Brains Project requests that you grant a license to the intellectual property rights in your contributions.
+
+The Contributor License Agreement (CLA) helps us ensure that the intellectual property embodied within the Thousand Brains Project remains unencumbered for use by the whole community. The CLA includes other terms as well and is for your protection as a contributor as well as the protection of the Thousand Brains Project and its users; it does not change your rights to use your contributions for any other purpose.
 
 ## How to sign the CLA
 


### PR DESCRIPTION
Additional context in the README.

@nielsleadholm, it wasn't clear to me where linking to https://thousandbrainsproject.readme.io/docs/why-contribute would go. I assume that people will be directed to this repository to sign from other places and they are unlikely to start here.