### PR TITLE
fix: make dist/index.js match the source code

### DIFF
--- a/.github/actions/upload_signature_backup/dist/index.js
+++ b/.github/actions/upload_signature_backup/dist/index.js
@@ -62870,7 +62870,6 @@ const signatureBackupBucketName = _actions_core__WEBPACK_IMPORTED_MODULE_0__.get
 const signatureBackupBucketRegion = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput("signature-backup-bucket-region");
 const signatureArtifactPath = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput("signature-artifact-path");
 const signatureArtifactName = (0,node_path__WEBPACK_IMPORTED_MODULE_2__.basename)(signatureArtifactPath);
-_actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`signatureArtifactName: ${signatureArtifactName}`);
 const s3 = new _aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_3__.S3Client({
     credentials: (0,_aws_sdk_credential_providers__WEBPACK_IMPORTED_MODULE_4__.fromEnv)(),
     region: signatureBackupBucketRegion
@@ -62880,8 +62879,6 @@ const putObject = {
     Key: signatureArtifactName,
     Body: await (0,node_fs_promises__WEBPACK_IMPORTED_MODULE_1__.readFile)(signatureArtifactPath)
 };
-const { Bucket, Key } = putObject;
-_actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`putObject: ${JSON.stringify({ Bucket, Key })}`);
 try {
     await s3.send(new _aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_3__.PutObjectCommand(putObject));
 }

--- a/.github/actions/upload_signature_backup/dist/index.js
+++ b/.github/actions/upload_signature_backup/dist/index.js
@@ -62843,12 +62843,14 @@ exports["default"] = _default;
 __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __webpack_async_result__) => { try {
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(7484);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var _aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(3711);
-/* harmony import */ var _aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__nccwpck_require__.n(_aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var _aws_sdk_credential_providers__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(9719);
-/* harmony import */ var _aws_sdk_credential_providers__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__nccwpck_require__.n(_aws_sdk_credential_providers__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(3711);
+/* harmony import */ var _aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__nccwpck_require__.n(_aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _aws_sdk_credential_providers__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(9719);
+/* harmony import */ var _aws_sdk_credential_providers__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__nccwpck_require__.n(_aws_sdk_credential_providers__WEBPACK_IMPORTED_MODULE_4__);
 /* harmony import */ var node_fs_promises__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(1455);
 /* harmony import */ var node_fs_promises__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(node_fs_promises__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var node_path__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(6760);
+/* harmony import */ var node_path__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__nccwpck_require__.n(node_path__WEBPACK_IMPORTED_MODULE_2__);
 /**
  * Copyright 2025 Thousand Brains Project
  *
@@ -62863,12 +62865,14 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 
 
 
+
 const signatureBackupBucketName = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput("signature-backup-bucket-name");
 const signatureBackupBucketRegion = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput("signature-backup-bucket-region");
-const signatureArtifactName = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput("signature-artifact-name");
 const signatureArtifactPath = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput("signature-artifact-path");
-const s3 = new _aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_2__.S3Client({
-    credentials: (0,_aws_sdk_credential_providers__WEBPACK_IMPORTED_MODULE_3__.fromEnv)(),
+const signatureArtifactName = (0,node_path__WEBPACK_IMPORTED_MODULE_2__.basename)(signatureArtifactPath);
+_actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`signatureArtifactName: ${signatureArtifactName}`);
+const s3 = new _aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_3__.S3Client({
+    credentials: (0,_aws_sdk_credential_providers__WEBPACK_IMPORTED_MODULE_4__.fromEnv)(),
     region: signatureBackupBucketRegion
 });
 const putObject = {
@@ -62876,8 +62880,10 @@ const putObject = {
     Key: signatureArtifactName,
     Body: await (0,node_fs_promises__WEBPACK_IMPORTED_MODULE_1__.readFile)(signatureArtifactPath)
 };
+const { Bucket, Key } = putObject;
+_actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`putObject: ${JSON.stringify({ Bucket, Key })}`);
 try {
-    await s3.send(new _aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_2__.PutObjectCommand(putObject));
+    await s3.send(new _aws_sdk_client_s3__WEBPACK_IMPORTED_MODULE_3__.PutObjectCommand(putObject));
 }
 catch (error) {
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`Failed to upload signature backup: ${error}`);
@@ -62997,6 +63003,13 @@ module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:events"
 /***/ ((module) => {
 
 module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:fs/promises");
+
+/***/ }),
+
+/***/ 6760:
+/***/ ((module) => {
+
+module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:path");
 
 /***/ }),
 

--- a/.github/actions/upload_signature_backup/src/index.ts
+++ b/.github/actions/upload_signature_backup/src/index.ts
@@ -18,6 +18,7 @@ const signatureBackupBucketName = core.getInput("signature-backup-bucket-name");
 const signatureBackupBucketRegion = core.getInput("signature-backup-bucket-region");
 const signatureArtifactPath = core.getInput("signature-artifact-path");
 const signatureArtifactName = basename(signatureArtifactPath);
+core.info(`signatureArtifactName: ${signatureArtifactName}`);
 
 const s3 = new S3Client(
     {
@@ -31,6 +32,8 @@ const putObject: PutObjectCommandInput =
     Key: signatureArtifactName,
     Body: await readFile(signatureArtifactPath)
 }
+const { Bucket, Key } = putObject;
+core.info(`putObject: ${JSON.stringify({ Bucket, Key })}`);
 try
 {
     await s3.send(new PutObjectCommand(putObject));

--- a/.github/actions/upload_signature_backup/src/index.ts
+++ b/.github/actions/upload_signature_backup/src/index.ts
@@ -18,7 +18,6 @@ const signatureBackupBucketName = core.getInput("signature-backup-bucket-name");
 const signatureBackupBucketRegion = core.getInput("signature-backup-bucket-region");
 const signatureArtifactPath = core.getInput("signature-artifact-path");
 const signatureArtifactName = basename(signatureArtifactPath);
-core.info(`signatureArtifactName: ${signatureArtifactName}`);
 
 const s3 = new S3Client(
     {
@@ -32,8 +31,6 @@ const putObject: PutObjectCommandInput =
     Key: signatureArtifactName,
     Body: await readFile(signatureArtifactPath)
 }
-const { Bucket, Key } = putObject;
-core.info(`putObject: ${JSON.stringify({ Bucket, Key })}`);
 try
 {
     await s3.send(new PutObjectCommand(putObject));


### PR DESCRIPTION
This pull request updates the `dist/index.js` for the `upload_signature_backup` action to match the source code in `src/index.ts`. 

My error was the following sequence of events:
- `npm run build` to generate `dist/index.js`
- update `src/index.ts` to create artifact name from artifact path
- **_forget to regenerate `dist/index.js`_**

As can be seen from the changeset, `dist/index.js` now matches the source to create the artifact name from the path: `.getInput("signature-artifact-name")` is gone and replaced with `.basename)(signatureArtifactPath);`.

This should resolve the observed error for this action:
```
Run ./.github/actions/upload_signature_backup
  with:
    signature-artifact-path: tristanls-signature-cla-v1-17.json
    signature-backup-bucket-name: s3-clasignaturesbackupbucket-vubykptecpua
    signature-backup-bucket-region: us-east-2
  env:
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
Error: Failed to upload signature backup: Error: Empty value provided for input HTTP label: Key.
```
The reason for the error is that the previous `dist/index.js` code was using the non-existent input `signature-artifact-name` for the `Key` value, hence the "empty value" error.